### PR TITLE
Catch a ValueError that is uncaught

### DIFF
--- a/flask_oidc/__init__.py
+++ b/flask_oidc/__init__.py
@@ -439,6 +439,10 @@ class OpenIDConnect(object):
                 logger.debug("Expired ID token, credentials missing",
                              exc_info=True)
                 return self.redirect_to_auth_server(request.url)
+            except ValueError:
+                logger.debug("Credentials missing",
+                             exc_info=True)
+                return self.redirect_to_auth_server(request.url)
 
             # refresh and store credentials
             try:


### PR DESCRIPTION
 when credentials_store is missing a Key after timeout. 
Occurs when using Redis as a credentials store.