### PR TITLE
Fix link URL

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "docs/_themes"]
 	path = docs/_themes
-	url = git://github.com/mitsuhiko/flask-sphinx-themes.git
+	url = https://github.com/mitsuhiko/flask-sphinx-themes


### PR DESCRIPTION
According to https://github.blog/2021-09-01-improving-git-protocol-security-github/#no-more-unauthenticated-git, starting Nov 2 `git://` URLs are not allowed anymore and are welcomed with errors like:

```
fatal: remote error: 
  The unauthenticated git protocol on port 9418 is no longer supported.
fatal: clone of 'git://github.com/mitsuhiko/flask-sphinx-themes.git'
```

Switching to `https://` seems to fix this issue.